### PR TITLE
Typos, sizing & Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ To embed an icon, use the `{{< fa >}}` shortcode. For example:
 {{< fa brands bluetooth >}}
 ```
 
-This extension includes support for only free Font Awesome icons (there are roughly 2,000 free icons, while the complete set of Pro icons consists of more than 16,000). You can browse all of the available free icons here:
+This extension includes support for only free Font Awesome icons (there are roughly 2,000 free icons, while the complete set of Pro icons consists of more than 16,000).
+You can browse all of the available free icons here:
 
 <https://fontawesome.com/search?m=free>
 
-### Brands
+### HTML formats
 
-Note that there is a `brands` prefix used within the `bluetooth` example above. If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier. For example, if you search the free icons for "github" and then click on the `github` icon, you'll see this as the suggested HTML to embed the icon:
+#### Brands
+
+Note that there is a `brands` prefix used within the `bluetooth` example above.
+If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier when using any HTML format.
+For example, if you search the free icons for "github" and then click on the `github` icon, you'll see this as the suggested HTML to embed the icon:
 
 ```html
 <i class="fa-brands fa-github"></i>
@@ -39,6 +44,36 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 ```default
 {{< fa brands github }}
 ```
+
+#### Sizing Icons
+
+Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.
+
+- Relative sizing: `{{< fa brands github 2xl >}}`
+
+  | Relative Sizing Class | Font Size | Equivalent in Pixels |
+  |-----------------------|-----------|----------------------|
+  | fa-2xs                | 0.625em   | 10px                 |
+  | fa-xs                 | 0.75em    | 12px                 |
+  | fa-sm                 | 0.875em   | 14px                 |
+  | fa-lg                 | 1.25em    | 20px                 |
+  | fa-xl                 | 1.5em     | 24px                 |
+  | fa-2xl                | 2em       | 32px                 |
+
+- Literal sizing: `{{< fa brands github 5x >}}`
+
+  | Literal Sizing Class | Font Size |
+  |----------------------|-----------|
+  | fa-1x                | 1em       |
+  | fa-2x                | 2em       |
+  | fa-3x                | 3em       |
+  | fa-4x                | 4em       |
+  | fa-5x                | 5em       |
+  | fa-6x                | 6em       |
+  | fa-7x                | 7em       |
+  | fa-8x                | 8em       |
+  | fa-9x                | 9em       |
+  | fa-10x               | 10em      |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ If you're using version control, you will want to check in this directory.
 
 ## Using
 
-To embed an icon, use the `{{< fa >}}` shortcode. For example:
+To embed an icon, use the `{{< fa >}}` shortcode.
+For example:
 
 ```default
 {{< fa thumbs-up >}} 
 {{< fa folder >}}
 {{< fa chess-pawn }}
 {{< fa brands bluetooth >}}
+{{< fa brands twitter size=2xl >}}
+{{< fa brands github size=5x >}}
+{{< fa enveloppe title="An enveloppe" >}}
 ```
 
 This extension includes support for only free Font Awesome icons (there are roughly 2,000 free icons, while the complete set of Pro icons consists of more than 16,000).

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ When the size is invalid, no size changes are made.
 
 - LaTeX sizing: `{{< fa battery-half size=Huge >}}`.
 
-  | Sizing Command                  | Font Size (LaTeX)    | Font Size (HTML) |
-  | ------------------------------- | -------------------- | ---------------- |
+  | Sizing Command                   | Font Size (LaTeX)    | Font Size (HTML) |
+  | -------------------------------- | -------------------- | ---------------- |
   | tiny (= `\tiny`)                 | 5pt                  | 0.5em            |
   | scriptsize (= `\scriptsize`)     | 7pt                  | 0.7em            |
   | footnotesize (= `\footnotesize`) | 8pt                  | 0.8em            |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To embed an icon, use the `{{< fa >}}` shortcode. For example:
 {{< fa brands bluetooth >}}
 {{< fa brands twitter size=2xl >}}
 {{< fa brands github size=5x >}}
+{{< fa battery-half size=Huge >}}
 {{< fa envelope title="An envelope" >}}
 ```
 
@@ -51,7 +52,7 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.  
 When the size is invalid, no size changes are made.
 
-- Relative sizing[^1]: `{{< fa brands github size=2xl >}}`.
+- Relative sizing[^1]: `{{< fa battery-half size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   |-----------------------|-----------|----------------------|
@@ -62,7 +63,7 @@ When the size is invalid, no size changes are made.
   | fa-xl                 | 1.5em     | 24px                 |
   | fa-2xl                | 2em       | 32px                 |
 
-- Literal sizing[^1]: `{{< fa brands github size=5x >}}`.
+- Literal sizing[^1]: `{{< fa battery-half size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
   |----------------------|-----------|
@@ -77,7 +78,7 @@ When the size is invalid, no size changes are made.
   | fa-9x                | 9em       |
   | fa-10x               | 10em      |
 
-- LaTeX sizing: `{{< fa brands github size=Huge >}}`.
+- LaTeX sizing: `{{< fa battery-half size=Huge >}}`.
 
   | Sizing Command   | Font Size (LaTeX)    | Font Size (HTML) |
   | ---------------- | -------------------- | ---------------- |
@@ -109,7 +110,7 @@ This will produce the following HTML:
 
 More details on Font Awesome accessibility at <https://fontawesome.com/docs/web/dig-deeper/accessibility>.
 
-[^1]: HTML format only.
+[^1]: HTML formats only.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're using version control, you will want to check in this directory.
 
 To embed an icon, use the `{{< fa >}}` shortcode. For example:
 
-```
+```default
 {{< fa thumbs-up >}} 
 {{< fa folder >}}
 {{< fa chess-pawn }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For example:
 {{< fa brands bluetooth >}}
 {{< fa brands twitter size=2xl >}}
 {{< fa brands github size=5x >}}
-{{< fa enveloppe title="An enveloppe" >}}
+{{< fa envelope title="An envelope" >}}
 ```
 
 This extension includes support for only free Font Awesome icons (there are roughly 2,000 free icons, while the complete set of Pro icons consists of more than 16,000).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can browse all of the available free icons here:
 
 <https://fontawesome.com/search?m=free>
 
-### Brands (HTML)
+### Brands[^1]
 
 Note that there is a `brands` prefix used within the `bluetooth` example above.
 If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier when using any HTML format.
@@ -48,12 +48,10 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 
 ### Sizing Icons
 
-#### HTML formats
-
 Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.  
 When the size is invalid, no size changes are made.
 
-- Relative sizing: `{{< fa brands github size=2xl >}}`.
+- Relative sizing[^1]: `{{< fa brands github size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   |-----------------------|-----------|----------------------|
@@ -64,7 +62,7 @@ When the size is invalid, no size changes are made.
   | fa-xl                 | 1.5em     | 24px                 |
   | fa-2xl                | 2em       | 32px                 |
 
-- Literal sizing: `{{< fa brands github size=5x >}}`.
+- Literal sizing[^1]: `{{< fa brands github size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
   |----------------------|-----------|
@@ -79,25 +77,22 @@ When the size is invalid, no size changes are made.
   | fa-9x                | 9em       |
   | fa-10x               | 10em      |
 
-#### LaTeX formats
+- LaTeX sizing: `{{< fa brands github size=Huge >}}`.
 
-LaTex sizing for icons works using the regular LaTeX commands for font size, `{{< fa brands github size=Huge >}}`.  
-When the size is invalid, no size changes are made.
+  | Sizing Command   | Font Size (LaTeX)    | Font Size (HTML) |
+  | ---------------- | -------------------- | ---------------- |
+  | `\tiny`          | 5pt                  | 0.5em            |
+  | `\scriptsize`    | 7pt                  | 0.7em            |
+  | `\footnotesize`  | 8pt                  | 0.8em            |
+  | `\small`         | 9pt                  | 0.9em            |
+  | `\normalsize`    | 10pt (document size) | 1em              |
+  | `\large`         | 12pt                 | 1.25em           |
+  | `\Large`         | 14.4pt               | 1.5em            |
+  | `\LARGE`         | 17.28pt              | 1.75em           |
+  | `\huge`          | 20.74pt              | 2em              |
+  | `\Huge`          | 24.88pt              | 2.5em            |
 
-| Sizing Command   | Font Size            |
-| ---------------- | -------------------- |
-| `\tiny`          | 5pt                  |
-| `\scriptsize`    | 7pt                  |
-| `\footnotesize`  | 8pt                  |
-| `\small`         | 9pt                  |
-| `\normalsize`    | 10pt (document size) |
-| `\large`         | 12pt                 |
-| `\Large`         | 14.4pt               |
-| `\LARGE`         | 17.28pt              |
-| `\huge`          | 20.74pt              |
-| `\Huge`          | 24.88pt              |
-
-### Accessibility (HTML)
+### Accessibility[^1]
 
 If the icon is being used in place of some text,
 just add some descriptive text in the title argument:
@@ -113,6 +108,8 @@ This will produce the following HTML:
 ```
 
 More details on Font Awesome accessibility at <https://fontawesome.com/docs/web/dig-deeper/accessibility>.
+
+[^1]: HTML format only.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 
 ### Sizing Icons
 
-### HTML formats
+#### HTML formats
 
 Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.  
 When the size is invalid, no size changes are made.
@@ -79,7 +79,7 @@ When the size is invalid, no size changes are made.
   | fa-9x                | 9em       |
   | fa-10x               | 10em      |
 
-### LaTeX formats
+#### LaTeX formats
 
 LaTex sizing for icons works using the regular LaTeX commands for font size, `{{< fa brands github size=Huge >}}`.  
 When the size is invalid, no size changes are made.

--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ When the size is invalid, no size changes are made.
 
 - LaTeX sizing: `{{< fa battery-half size=Huge >}}`.
 
-  | Sizing Command   | Font Size (LaTeX)    | Font Size (HTML) |
-  | ---------------- | -------------------- | ---------------- |
-  | `\tiny`          | 5pt                  | 0.5em            |
-  | `\scriptsize`    | 7pt                  | 0.7em            |
-  | `\footnotesize`  | 8pt                  | 0.8em            |
-  | `\small`         | 9pt                  | 0.9em            |
-  | `\normalsize`    | 10pt (document size) | 1em              |
-  | `\large`         | 12pt                 | 1.25em           |
-  | `\Large`         | 14.4pt               | 1.5em            |
-  | `\LARGE`         | 17.28pt              | 1.75em           |
-  | `\huge`          | 20.74pt              | 2em              |
-  | `\Huge`          | 24.88pt              | 2.5em            |
+  | Sizing Command                  | Font Size (LaTeX)    | Font Size (HTML) |
+  | ------------------------------- | -------------------- | ---------------- |
+  | tiny (= `\tiny`)                 | 5pt                  | 0.5em            |
+  | scriptsize (= `\scriptsize`)     | 7pt                  | 0.7em            |
+  | footnotesize (= `\footnotesize`) | 8pt                  | 0.8em            |
+  | small (= `\small`)               | 9pt                  | 0.9em            |
+  | normalsize (= `\normalsize`)     | 10pt (document size) | 1em              |
+  | large (= `\large`)               | 12pt                 | 1.25em           |
+  | Large (= `\Large`)               | 14.4pt               | 1.5em            |
+  | LARGE (= `\LARGE`)               | 17.28pt              | 1.75em           |
+  | huge (= `\huge`)                 | 20.74pt              | 2em              |
+  | Huge (= `\Huge`)                 | 24.88pt              | 2.5em            |
 
 ### Accessibility[^1]
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This extension provides support including free icons provided by [Font Awesome](
 
 ## Installing
 
-```
-$ quarto install extension quarto-ext/fontawesome
+```sh
+quarto install extension quarto-ext/fontawesome
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -13,13 +13,13 @@ If you're using version control, you will want to check in this directory.
 
 ## Using
 
-To embed an icon, use the `{{{< fa >}}}` shortcode. For example:
+To embed an icon, use the `{{< fa >}}` shortcode. For example:
 
 ```
 {{< fa thumbs-up >}} 
 {{< fa folder >}}
 {{< fa chess-pawn }}
-{{{< fa brands bluetooth }}}
+{{< fa brands bluetooth >}}
 ```
 
 This extension includes support for only free Font Awesome icons (there are roughly 2,000 free icons, while the complete set of Pro icons consists of more than 16,000). You can browse all of the available free icons here:
@@ -37,12 +37,11 @@ Note that there is a `brands` prefix used within the `bluetooth` example above. 
 The `fa-brands` indicates that the icon is in the `brands` collection. To use this with Quarto just add the `brands` collection prefix as follows:
 
 ```default
-{{{< fa brands github }}}
+{{< fa brands github }}
 ```
 
 ## Example
 
-Here is the source code for a minimal example: [example.qmd](example.qmd)
+Here is the source code for a minimal example: [example.qmd](example.qmd).
 
 This is the output of `example.qmd` for [HTML](https://quarto-ext.github.io/fontawesome/) and [PDF](https://quarto-ext.github.io/fontawesome/example.pdf).
-

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ When the size is invalid, no size changes are made.
 LaTex sizing for icons works using the regular LaTeX commands for font size, `{{< fa brands github size=Huge >}}`.  
 When the size is invalid, no size changes are made.
 
-| Sizing Command | Font Size            |
-| -------------- | -------------------- |
-| \tiny          | 5pt                  |
-| \scriptsize    | 7pt                  |
-| \footnotesize  | 8pt                  |
-| \small         | 9pt                  |
-| \normalsize    | 10pt (document size) |
-| \large         | 12pt                 |
-| \Large         | 14.4pt               |
-| \LARGE         | 17.28pt              |
-| \huge          | 20.74pt              |
-| \Huge          | 24.88pt              |
+| Sizing Command   | Font Size            |
+| ---------------- | -------------------- |
+| `\tiny`          | 5pt                  |
+| `\scriptsize`    | 7pt                  |
+| `\footnotesize`  | 8pt                  |
+| `\small`         | 9pt                  |
+| `\normalsize`    | 10pt (document size) |
+| `\large`         | 12pt                 |
+| `\Large`         | 14.4pt               |
+| `\LARGE`         | 17.28pt              |
+| `\huge`          | 20.74pt              |
+| `\Huge`          | 24.88pt              |
 
 ### Accessibility (HTML)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 
 Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.
 
-- Relative sizing: `{{< fa brands github 2xl >}}`
+- Relative sizing: `{{< fa brands github size=2xl >}}`
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   |-----------------------|-----------|----------------------|
@@ -60,7 +60,7 @@ Font Awesome provides relative and literal sizing for icons as described in <htt
   | fa-xl                 | 1.5em     | 24px                 |
   | fa-2xl                | 2em       | 32px                 |
 
-- Literal sizing: `{{< fa brands github 5x >}}`
+- Literal sizing: `{{< fa brands github size=5x >}}`
 
   | Literal Sizing Class | Font Size |
   |----------------------|-----------|

--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ Font Awesome provides relative and literal sizing for icons as described in <htt
   | fa-9x                | 9em       |
   | fa-10x               | 10em      |
 
+#### Accessibility
+
+If the icon is being used in place of some text,
+just add some descriptive text in the title argument:
+
+```default
+{{< fa envelope title="An envelope" >}}
+```
+
+This will produce the following HTML:
+
+```html
+<i class="fa-solid fa-envelope" title="An envelope" aria-hidden="true"></i>
+```
+
+More details on Font Awesome accessibility at <https://fontawesome.com/docs/web/dig-deeper/accessibility>.
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd).

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ You can browse all of the available free icons here:
 
 <https://fontawesome.com/search?m=free>
 
-### HTML formats
-
-#### Brands
+### Brands (HTML)
 
 Note that there is a `brands` prefix used within the `bluetooth` example above.
 If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier when using any HTML format.
@@ -48,11 +46,14 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 {{< fa brands github >}}
 ```
 
-#### Sizing Icons
+### Sizing Icons
 
-Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.
+### HTML formats
 
-- Relative sizing: `{{< fa brands github size=2xl >}}`
+Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.  
+When the size is invalid, no size changes are made.
+
+- Relative sizing: `{{< fa brands github size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   |-----------------------|-----------|----------------------|
@@ -63,7 +64,7 @@ Font Awesome provides relative and literal sizing for icons as described in <htt
   | fa-xl                 | 1.5em     | 24px                 |
   | fa-2xl                | 2em       | 32px                 |
 
-- Literal sizing: `{{< fa brands github size=5x >}}`
+- Literal sizing: `{{< fa brands github size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
   |----------------------|-----------|
@@ -78,7 +79,25 @@ Font Awesome provides relative and literal sizing for icons as described in <htt
   | fa-9x                | 9em       |
   | fa-10x               | 10em      |
 
-#### Accessibility
+### LaTeX formats
+
+LaTex sizing for icons works using the regular LaTeX commands for font size, `{{< fa brands github size=Huge >}}`.  
+When the size is invalid, no size changes are made.
+
+| Sizing Command | Font Size            |
+| -------------- | -------------------- |
+| \tiny          | 5pt                  |
+| \scriptsize    | 7pt                  |
+| \footnotesize  | 8pt                  |
+| \small         | 9pt                  |
+| \normalsize    | 10pt (document size) |
+| \large         | 12pt                 |
+| \Large         | 14.4pt               |
+| \LARGE         | 17.28pt              |
+| \huge          | 20.74pt              |
+| \Huge          | 24.88pt              |
+
+### Accessibility (HTML)
 
 If the icon is being used in place of some text,
 just add some descriptive text in the title argument:

--- a/_extensions/fontawesome/assets/css/latex-fontsize.css
+++ b/_extensions/fontawesome/assets/css/latex-fontsize.css
@@ -1,0 +1,30 @@
+.fa-tiny {
+  font-size: 0.5em;
+}
+.fa-scriptsize {
+  font-size: 0.7em;
+}
+.fa-footnotesize {
+  font-size: 0.8em;
+}
+.fa-small {
+  font-size: 0.9em;
+}
+.fa-normalsize {
+  font-size: 1em;
+}
+.fa-large {
+  font-size: 1.2em;
+}
+.fa-Large {
+  font-size: 1.5em;
+}
+.fa-LARGE {
+  font-size: 1.75em;
+}
+.fa-huge {
+  font-size: 2em;
+}
+.fa-Huge {
+  font-size: 2.5em;
+}

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -10,7 +10,7 @@ function ensureHtmlDeps()
   })
 end
 
-local function isempty(s)
+local function isEmpty(s)
   return s == nil or s == ''
 end
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -19,10 +19,7 @@ return {
       group = icon
       icon = pandoc.utils.stringify(args[2])
     end
-    local size = ""
-    if #args > 2 then
-      size = " fa-" .. pandoc.utils.stringify(args[3])
-    end
+    local size = " fa-" .. pandoc.utils.stringify(kwargs["size"])
 
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.isFormat("html:js") then

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -68,7 +68,7 @@ return {
       if isEmpty(isValidSize(size)) then
         return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
       else
-        return pandoc.RawInline('tex', "\\" .. size .. "{\\faIcon{" .. icon .. "}}")
+        return pandoc.RawInline('tex', "{\\" .. size .. "\\faIcon{" .. icon .. "}}")
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -1,8 +1,8 @@
-function ensureLatexDeps()
+local function ensureLatexDeps()
   quarto.doc.useLatexPackage("fontawesome5")
 end
 
-function ensureHtmlDeps()
+local function ensureHtmlDeps()
   quarto.doc.addHtmlDependency({
     name = 'fontawesome6',
     version = '0.1.0',
@@ -14,6 +14,27 @@ local function isEmpty(s)
   return s == nil or s == ''
 end
 
+local function isValidSize(size)
+  local validSizes = {
+    "tiny",
+    "scriptsize",
+    "footnotesize",
+    "small",
+    "normalsize",
+    "large",
+    "Large",
+    "LARGE",
+    "huge",
+    "Huge"
+  }
+  for _, v in ipairs(validSizes) do
+    if v == size then
+      return size
+    end
+  end
+  return "normalsize"
+end
+
 return {
   ["fa"] = function(args, kwargs)
 
@@ -23,19 +44,20 @@ return {
       group = icon
       icon = pandoc.utils.stringify(args[2])
     end
-    local size = pandoc.utils.stringify(kwargs["size"])
-    if not isempty(size) then
-      size = " fa-" .. size
-    end
     
     local title = pandoc.utils.stringify(kwargs["title"])
-    if not isempty(title) then
+    if not isEmpty(title) then
       title = " title=\"" .. title  .. "\" aria-hidden=\"true\""
     end
+
+    local size = pandoc.utils.stringify(kwargs["size"])
     
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.isFormat("html:js") then
       ensureHtmlDeps()
+      if not isEmpty(size) then
+        size = " fa-" .. size
+      end
       return pandoc.RawInline(
         'html',
         "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. "></i>"
@@ -43,10 +65,13 @@ return {
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.isFormat("pdf") then
       ensureLatexDeps()
-      return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}") 
+      if isEmpty(size) then
+        return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
+      else
+        return pandoc.RawInline('tex', "\\" .. isValidSize(size) .. "{\\faIcon{" .. icon .. "}}")
+      end
     else
       return pandoc.Null()
     end
-
   end
 }

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -19,11 +19,15 @@ return {
       group = icon
       icon = pandoc.utils.stringify(args[2])
     end
+    local size = ""
+    if #args > 2 then
+      size = " fa-" .. pandoc.utils.stringify(args[3])
+    end
 
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.isFormat("html:js") then
       ensureHtmlDeps()
-      return pandoc.RawInline('html', "<i class=\"fa-" .. group .. " fa-" .. icon .. "\"></i>")
+      return pandoc.RawInline('html', "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"></i>")
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.isFormat("pdf") then
       ensureLatexDeps()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -10,6 +10,10 @@ function ensureHtmlDeps()
   })
 end
 
+local function isempty(s)
+  return s == nil or s == ''
+end
+
 return {
   ["fa"] = function(args, kwargs)
 
@@ -19,12 +23,23 @@ return {
       group = icon
       icon = pandoc.utils.stringify(args[2])
     end
-    local size = " fa-" .. pandoc.utils.stringify(kwargs["size"])
-
+    local size = pandoc.utils.stringify(kwargs["size"])
+    if not isempty(size) then
+      size = " fa-" .. size
+    end
+    
+    local title = pandoc.utils.stringify(kwargs["title"])
+    if not isempty(title) then
+      title = " title=\"" .. title  .. "\" aria-hidden=\"true\""
+    end
+    
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.isFormat("html:js") then
       ensureHtmlDeps()
-      return pandoc.RawInline('html', "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"></i>")
+      return pandoc.RawInline(
+        'html',
+        "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. "></i>"
+      )
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.isFormat("pdf") then
       ensureLatexDeps()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -6,7 +6,7 @@ local function ensureHtmlDeps()
   quarto.doc.addHtmlDependency({
     name = 'fontawesome6',
     version = '0.1.0',
-    stylesheets = {'assets/css/all.css'}
+    stylesheets = {'assets/css/all.css', 'assets/css/latex-fontsize.css'}
   })
 end
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -47,7 +47,7 @@ return {
     
     local title = pandoc.utils.stringify(kwargs["title"])
     if not isEmpty(title) then
-      title = " title=\"" .. title  .. "\" aria-hidden=\"true\""
+      title = " title=\"" .. title  .. "\""
     end
 
     local size = pandoc.utils.stringify(kwargs["size"])
@@ -60,7 +60,7 @@ return {
       end
       return pandoc.RawInline(
         'html',
-        "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. "></i>"
+        "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. " aria-hidden=\"true\"></i>"
       )
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.isFormat("pdf") then

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -32,7 +32,7 @@ local function isValidSize(size)
       return size
     end
   end
-  return "normalsize"
+  return ""
 end
 
 return {
@@ -65,10 +65,10 @@ return {
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.isFormat("pdf") then
       ensureLatexDeps()
-      if isEmpty(size) then
+      if isEmpty(isValidSize(size)) then
         return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
       else
-        return pandoc.RawInline('tex', "\\" .. isValidSize(size) .. "{\\faIcon{" .. icon .. "}}")
+        return pandoc.RawInline('tex', "\\" .. size .. "{\\faIcon{" .. icon .. "}}")
       end
     else
       return pandoc.Null()

--- a/example.qmd
+++ b/example.qmd
@@ -20,12 +20,13 @@ It provides an `{{{< fa >}}}` shortcode:
 
 For example:
 
-| Shortcode                                     | Icon                                      |
-|-----------------------------------------------|-------------------------------------------|
-| `{{{< fa thumbs-up >}}}`                      | {{< fa thumbs-up >}}                      |
-| `{{{< fa folder >}}}`                         | {{< fa folder >}}                         |
-| `{{{< fa chess-pawn >}}}`                     | {{< fa chess-pawn >}}                     |
-| `{{{< fa brands bluetooth >}}}`               | {{< fa brands bluetooth >}}               |
-| `{{{< fa brands twitter size=2xl >}}}`        | {{< fa brands twitter size=2xl >}}        |
-| `{{{< fa brands github size=5x >}}}`          | {{< fa brands github size=5x >}}          |
-| `{{{< fa envelope title="An envelope" >}}}`   | {{< fa envelope title="An envelope" >}}   |
+| Shortcode                                      | Icon                                      |
+|------------------------------------------------|-------------------------------------------|
+| `{{{< fa thumbs-up >}}}`                       | {{< fa thumbs-up >}}                      |
+| `{{{< fa folder >}}}`                          | {{< fa folder >}}                         |
+| `{{{< fa chess-pawn >}}}`                      | {{< fa chess-pawn >}}                     |
+| `{{{< fa brands bluetooth >}}}`                | {{< fa brands bluetooth >}}               |
+| `{{{< fa brands twitter size=2xl >}}}` (HTML)  | {{< fa brands twitter size=2xl >}}        |
+| `{{{< fa brands github size=5x >}}}` (HTML     | {{< fa brands github size=5x >}}          |
+| `{{{< fa brands github size=Huge >}}}` (LaTeX) | {{< fa brands github size=Huge >}}        |
+| `{{{< fa envelope title="An envelope" >}}}`    | {{< fa envelope title="An envelope" >}}   |

--- a/example.qmd
+++ b/example.qmd
@@ -20,11 +20,12 @@ It provides an `{{{< fa >}}}` shortcode:
 
 For example:
 
-| Shortcode                           | Icon                            |
-|-------------------------------------|---------------------------------|
-| `{{{< fa thumbs-up >}}}`            | {{< fa thumbs-up >}}            |
-| `{{{< fa folder >}}}`               | {{< fa folder >}}               |
-| `{{{< fa chess-pawn >}}}`           | {{< fa chess-pawn >}}           |
-| `{{{< fa brands bluetooth >}}}`     | {{< fa brands bluetooth >}}     |
-| `{{{< fa brands twitter size=2xl >}}}`   | {{< fa brands twitter size=2xl >}}   |
-| `{{{< fa brands github size=5x >}}}`     | {{< fa brands github size=5x >}}     |
+| Shortcode                                     | Icon                                      |
+|-----------------------------------------------|-------------------------------------------|
+| `{{{< fa thumbs-up >}}}`                      | {{< fa thumbs-up >}}                      |
+| `{{{< fa folder >}}}`                         | {{< fa folder >}}                         |
+| `{{{< fa chess-pawn >}}}`                     | {{< fa chess-pawn >}}                     |
+| `{{{< fa brands bluetooth >}}}`               | {{< fa brands bluetooth >}}               |
+| `{{{< fa brands twitter size=2xl >}}}`        | {{< fa brands twitter size=2xl >}}        |
+| `{{{< fa brands github size=5x >}}}`          | {{< fa brands github size=5x >}}          |
+| `{{{< fa enveloppe title="An enveloppe" >}}}` | {{< fa enveloppe title="An enveloppe" >}} |

--- a/example.qmd
+++ b/example.qmd
@@ -26,5 +26,5 @@ For example:
 | `{{{< fa folder >}}}`               | {{< fa folder >}}               |
 | `{{{< fa chess-pawn >}}}`           | {{< fa chess-pawn >}}           |
 | `{{{< fa brands bluetooth >}}}`     | {{< fa brands bluetooth >}}     |
-| `{{{< fa brands twitter 2xl >}}}`   | {{< fa brands twitter 2xl >}}   |
-| `{{{< fa brands github 5x >}}}`     | {{< fa brands github 5x >}}     |
+| `{{{< fa brands twitter size=2xl >}}}`   | {{< fa brands twitter size=2xl >}}   |
+| `{{{< fa brands github size=5x >}}}`     | {{< fa brands github size=5x >}}     |

--- a/example.qmd
+++ b/example.qmd
@@ -28,5 +28,5 @@ For example:
 | `{{{< fa brands bluetooth >}}}`                    | {{< fa brands bluetooth >}}               |
 | `{{{< fa brands twitter size=2xl >}}}` (HTML only) | {{< fa brands twitter size=2xl >}}        |
 | `{{{< fa brands github size=5x >}}}` (HTML only)   | {{< fa brands github size=5x >}}          |
-| `{{{< fa brands github size=Huge >}}}`             | {{< fa brands github size=Huge >}}        |
+| `{{{< fa battery-half size=Huge >}}}`              | {{< fa battery-half size=Huge >}}         |
 | `{{{< fa envelope title="An envelope" >}}}`        | {{< fa envelope title="An envelope" >}}   |

--- a/example.qmd
+++ b/example.qmd
@@ -20,13 +20,13 @@ It provides an `{{{< fa >}}}` shortcode:
 
 For example:
 
-| Shortcode                                      | Icon                                      |
-|------------------------------------------------|-------------------------------------------|
-| `{{{< fa thumbs-up >}}}`                       | {{< fa thumbs-up >}}                      |
-| `{{{< fa folder >}}}`                          | {{< fa folder >}}                         |
-| `{{{< fa chess-pawn >}}}`                      | {{< fa chess-pawn >}}                     |
-| `{{{< fa brands bluetooth >}}}`                | {{< fa brands bluetooth >}}               |
-| `{{{< fa brands twitter size=2xl >}}}` (HTML)  | {{< fa brands twitter size=2xl >}}        |
-| `{{{< fa brands github size=5x >}}}` (HTML     | {{< fa brands github size=5x >}}          |
-| `{{{< fa brands github size=Huge >}}}` (LaTeX) | {{< fa brands github size=Huge >}}        |
-| `{{{< fa envelope title="An envelope" >}}}`    | {{< fa envelope title="An envelope" >}}   |
+| Shortcode                                          | Icon                                      |
+| -------------------------------------------------- | ----------------------------------------- |
+| `{{{< fa thumbs-up >}}}`                           | {{< fa thumbs-up >}}                      |
+| `{{{< fa folder >}}}`                              | {{< fa folder >}}                         |
+| `{{{< fa chess-pawn >}}}`                          | {{< fa chess-pawn >}}                     |
+| `{{{< fa brands bluetooth >}}}`                    | {{< fa brands bluetooth >}}               |
+| `{{{< fa brands twitter size=2xl >}}}` (HTML only) | {{< fa brands twitter size=2xl >}}        |
+| `{{{< fa brands github size=5x >}}}` (HTML only)   | {{< fa brands github size=5x >}}          |
+| `{{{< fa brands github size=Huge >}}}`             | {{< fa brands github size=Huge >}}        |
+| `{{{< fa envelope title="An envelope" >}}}`        | {{< fa envelope title="An envelope" >}}   |

--- a/example.qmd
+++ b/example.qmd
@@ -5,17 +5,26 @@ format:
    pdf: default
 ---
 
-This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents. It provides an `{{{< fa >}}}` shortcode:
+This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents.
+It provides an `{{{< fa >}}}` shortcode:
 
-``` markdown
-{{{< fa icon-name >}}}
-```
+- Mandary `<icon-name>`:
+  ``` markdown
+  {{{< fa <icon-name> >}}}
+  ```
+
+- Optional `<group>` and `<size>`:
+  ``` markdown
+  {{{< fa <group> <icon-name> <size> >}}}
+  ```
 
 For example:
 
-| Shortcode                       | Icon                        |
-|---------------------------------|-----------------------------|
-| `{{{< fa thumbs-up >}}}`        | {{< fa thumbs-up >}}        |
-| `{{{< fa folder >}}}`           | {{< fa folder >}}           |
-| `{{{< fa chess-pawn >}}}`       | {{< fa chess-pawn >}}       |
-| `{{{< fa brands bluetooth >}}}` | {{< fa brands bluetooth >}} |
+| Shortcode                           | Icon                            |
+|-------------------------------------|---------------------------------|
+| `{{{< fa thumbs-up >}}}`            | {{< fa thumbs-up >}}            |
+| `{{{< fa folder >}}}`               | {{< fa folder >}}               |
+| `{{{< fa chess-pawn >}}}`           | {{< fa chess-pawn >}}           |
+| `{{{< fa brands bluetooth >}}}`     | {{< fa brands bluetooth >}}     |
+| `{{{< fa brands twitter 2xl >}}}`   | {{< fa brands twitter 2xl >}}   |
+| `{{{< fa brands github 5x >}}}`     | {{< fa brands github 5x >}}     |

--- a/example.qmd
+++ b/example.qmd
@@ -28,4 +28,4 @@ For example:
 | `{{{< fa brands bluetooth >}}}`               | {{< fa brands bluetooth >}}               |
 | `{{{< fa brands twitter size=2xl >}}}`        | {{< fa brands twitter size=2xl >}}        |
 | `{{{< fa brands github size=5x >}}}`          | {{< fa brands github size=5x >}}          |
-| `{{{< fa enveloppe title="An enveloppe" >}}}` | {{< fa enveloppe title="An enveloppe" >}} |
+| `{{{< fa envelope title="An envelope" >}}}` | {{< fa envelope title="An envelope" >}} |

--- a/example.qmd
+++ b/example.qmd
@@ -28,4 +28,4 @@ For example:
 | `{{{< fa brands bluetooth >}}}`               | {{< fa brands bluetooth >}}               |
 | `{{{< fa brands twitter size=2xl >}}}`        | {{< fa brands twitter size=2xl >}}        |
 | `{{{< fa brands github size=5x >}}}`          | {{< fa brands github size=5x >}}          |
-| `{{{< fa envelope title="An envelope" >}}}` | {{< fa envelope title="An envelope" >}} |
+| `{{{< fa envelope title="An envelope" >}}}`   | {{< fa envelope title="An envelope" >}}   |

--- a/example.qmd
+++ b/example.qmd
@@ -13,9 +13,9 @@ It provides an `{{{< fa >}}}` shortcode:
   {{{< fa <icon-name> >}}}
   ```
 
-- Optional `<group>` and `<size>`:
+- Optional `<group>`, `<size=...>`, and `<title=...>`:
   ``` markdown
-  {{{< fa <group> <icon-name> <size> >}}}
+  {{{< fa <group> <icon-name> <size=...> <title=...> >}}}
   ```
 
 For example:

--- a/example.qmd
+++ b/example.qmd
@@ -8,7 +8,7 @@ format:
 This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents.
 It provides an `{{{< fa >}}}` shortcode:
 
-- Mandary `<icon-name>`:
+- Mandatory `<icon-name>`:
   ``` markdown
   {{{< fa <icon-name> >}}}
   ```


### PR DESCRIPTION
This PR does:

- `README.md`:
  - Fix: removes the dollar sign which is copied when using the "copy" button on GitHub.
  - Fix: missing `>` in shorcodes (#2 #5 #9)
  - Fix: shortcores with extra `{` and `}` (only needed within Quarto document)  (#5 #9)

- `fontawesome.lua`:
  - Feat:
    - add relative and literal FA sizing option with a named argument in the shortcode `size=...` <https://fontawesome.com/docs/web/style/size> (#4)
    - add LaTeX font size commands with new css classes to make it work seamlessly between PDF and HTML formats.
  - Feat: add accessibility ("title" feature of FA WebKit <https://fontawesome.com/docs/web/dig-deeper/accessibility>) as a new named argument `title=...` and adds `aria-hidden="true"` to the HTML code (#8)