### PR TITLE
Added support for color (?)

### DIFF
--- a/_extensions/fontawesome/_extension.yml
+++ b/_extensions/fontawesome/_extension.yml
@@ -1,6 +1,6 @@
 title: Font Awesome support
 author: Carlos Scheidegger
-version: 1.1.0
+version: 1.1.2
 quarto-required: ">=1.2.269"
 contributes:
   shortcodes:

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -14,6 +14,38 @@ local function isEmpty(s)
   return s == nil or s == ''
 end
 
+local function getRgbTriplets(s)
+  local triplet = {}
+  for t in string.gmatch(string.match(s, 'rgb%(([^%)]+)%)'), "([^,]+)") do
+    table.insert(triplet, t)
+  end
+  return triplet
+end
+
+local function toRgbCss(s)
+  local triplet = {}
+  for k,t in pairs(getRgbTriplets(s)) do
+    if tonumber(t) <= 1 then
+      table.insert(triplet, string.format("%.0f", tonumber(t) * 255))
+    else
+      table.insert(triplet, t)
+    end
+  end
+  return table.concat(triplet, ",")
+end
+
+local function toRgbTex(s)
+  local triplet = {}
+  for k,t in pairs(getRgbTriplets(s)) do
+    if tonumber(t) > 1 then
+      table.insert(triplet, string.format("%.2f", tonumber(t) / 255))
+    else
+      table.insert(triplet, t)
+    end
+  end
+  return table.concat(triplet, ",")
+end
+
 local function isValidSize(size)
   local validSizes = {
     "tiny",
@@ -58,6 +90,7 @@ return {
     end
 
     local size = pandoc.utils.stringify(kwargs["size"])
+    local color = pandoc.utils.stringify(kwargs["color"])
     
     -- detect html (excluding epub which won't handle fa)
     if quarto.doc.is_format("html:js") then
@@ -65,18 +98,34 @@ return {
       if not isEmpty(size) then
         size = " fa-" .. size
       end
+      if not isEmpty(color) then
+        if string.find(color, '^rgb') then
+          color = " style=\"color:rgb(" .. toRgbCss(color) .. ");\""
+        else
+          color = " style=\"color:" .. color .. ";\""
+        end
+      end
       return pandoc.RawInline(
         'html',
-        "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. label .. "></i>"
+        "<i class=\"fa-" .. group .. " fa-" .. icon .. size .. "\"" .. title .. label .. color .. "></i>"
       )
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.is_format("pdf") then
       ensureLatexDeps()
-      if isEmpty(isValidSize(size)) then
-        return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
-      else
-        return pandoc.RawInline('tex', "{\\" .. size .. "\\faIcon{" .. icon .. "}}")
+      local tex = "\\faIcon{" .. icon .. "}"
+      if not isEmpty(isValidSize(size)) then
+        tex = "{\\" .. size .. tex .. "}"
       end
+      if not isEmpty(color) then
+        if string.find(color, '^#%x+') then 
+          tex = "\\textcolor[HTML]{" .. string.match(color, '#(%x+)') .. "}{" .. tex .. "}"
+        elseif string.find(color, '^rgb') then
+          tex = "\\textcolor[rgb]{" .. toRgbTex(color) .. "}{" .. tex .. "}"
+        else
+          tex = "\\textcolor{" .. color .. "}{" .. tex .. "}"
+        end
+      end
+      return pandoc.RawInline('tex', tex)
     else
       return pandoc.Null()
     end

--- a/example.qmd
+++ b/example.qmd
@@ -31,6 +31,15 @@ For example:
 | `{{{< fa battery-half size=Huge >}}}`              | {{< fa battery-half size=Huge >}}         |
 | `{{{< fa envelope title="An envelope" >}}}`        | {{< fa envelope title="An envelope" >}}   |
 
+Colors:
+
+| Shortcode                                               | Icon                                                |
+| ------------------------------------------------------- | --------------------------------------------------- |
+| `{{{< fa thumbs-up color=#0000ff >}}}`                  | {{< fa thumbs-up color=#0000ff >}}                  |
+| `{{{< fa thumbs-up color=rgb(0,255,0) >}}}`             | {{< fa thumbs-up color=rgb(0,255,0) >}}             |
+| `{{{< fa thumbs-up color=rgb(1,0,0) >}}}`               | {{< fa thumbs-up color=rgb(1,0,0) >}}               |
+| `{{{< fa thumbs-up color=rgb(1,0.1,0.8) size=Huge >}}}` | {{< fa thumbs-up color=rgb(1,0.1,0.8) size=Huge >}} |
+
 Note that the icon sets are currently not perfectly interchangeable across formats:
 
 - `html` uses FontAwesome 6.4.2


### PR DESCRIPTION
First time writing Lua and first time tweaking a Quarto extension, but I wanted the ability to specify a color for a fontawesome icon and _believe_ I've done it. Extension seems to run without a problem on my system (Quarto version 1.3.450 on a M2 Mac running Sonoma 14.2) so here's a pull request that is hopefully fairly easy to parse.

Color is supported in a few ways:

- If you use a name like 'red' or 'green' then that will (presumably) only work in TeX
- Hexadecimal seems to work in both
- RGB triplets seem to work in both (haven't tried with an alpha blend, that probably doesn't)
  - If the triplets are in the range 0..1 and you generate HTML then they'll be converted to 0..255
  - If the triplets are in the range 0..255 and you generate TeX then they'll be converted to 0..1

Examples in example.qmd.