### PR TITLE
Add typst support (#31)

### DIFF
--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -43,6 +43,33 @@ local function isValidSize(size)
   return ""
 end
 
+local function convert_fa_relative_size(size)
+  local validSizes = {
+    "2xs",
+    "xs",
+    "sm",
+    "lg",
+    "xl",
+    "2xl"
+  }
+  
+  local relativeSizes = {
+    "0.625em",
+    "0.75em",
+    "0.875em",
+    "1.25em",
+    "1.5em",
+    "2em"
+  }
+  
+  for i, v in ipairs(validSizes) do
+    if v == size then
+      return relativeSizes[i]
+    end
+  end
+  return size
+end
+
 return {
   ["fa"] = function(args, kwargs)
 
@@ -88,10 +115,27 @@ return {
     -- detect typst
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
-      if isEmpty(size) then
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
+      
+      local fill = pandoc.utils.stringify(kwargs["fill"])
+      if not isEmpty(fill) then
+        fill = ", fill: " .. fill
+      end
+      
+      if not isEmpty(size) then
+        size = convert_fa_relative_size(size)
+        size = ", size: " .. size
+      end
+      
+      if group == "brands" then
+        return pandoc.RawInline(
+          'typst',
+          "#fa-icon(\"" .. icon .. "\", fa-set: \"Brands\"" .. size .. fill .. ")"
+          )
       else
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: " .. size .. ")")
+        return pandoc.RawInline(
+            'typst',
+            "#fa-icon(\"" .. icon .. "\"" .. size .. fill .. ")"
+            )
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -50,7 +50,17 @@ local function convert_fa_relative_size(size)
     "sm",
     "lg",
     "xl",
-    "2xl"
+    "2xl",
+    "tiny",
+    "scriptsize",
+    "footnotesize",
+    "small",
+    "normalsize",
+    "large",
+    "Large",
+    "LARGE",
+    "huge",
+    "Huge"
   }
   
   local relativeSizes = {
@@ -59,7 +69,17 @@ local function convert_fa_relative_size(size)
     "0.875em",
     "1.25em",
     "1.5em",
-    "2em"
+    "2em",
+    "0.125em",
+    "0.5em",
+    "0.625em",
+    "0.75em",
+    "0.875em",
+    "1.25em",
+    "1.5em",
+    "2em",
+    "2.5em",
+    "3em"
   }
   
   for i, v in ipairs(validSizes) do
@@ -117,26 +137,23 @@ return {
       ensure_typst_font_awesome()
       
       local fill = pandoc.utils.stringify(kwargs["fill"])
-      if not isEmpty(fill) then
-        fill = ", fill: " .. fill
-      end
-      
       if not isEmpty(size) then
         size = convert_fa_relative_size(size)
-        size = ", size: " .. size
+        size = "size: " .. size
       end
       
-      if group == "brands" then
-        return pandoc.RawInline(
-          'typst',
-          "#fa-icon(\"" .. icon .. "\", fa-set: \"Brands\"" .. size .. fill .. ")"
-          )
-      else
-        return pandoc.RawInline(
-            'typst',
-            "#fa-icon(\"" .. icon .. "\"" .. size .. fill .. ")"
-            )
+      if not isEmpty(fill) then
+        fill = "fill: " .. fill
+        
+        if not isEmpty(size) then
+          size = size .. ", "
+        end
       end
+
+      return pandoc.RawInline(
+        'typst',
+        "#fa-" .. icon .. "(" .. size .. fill .. ")"
+        )
     else
       return pandoc.Null()
     end

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -136,14 +136,14 @@ return {
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
       
-      local fill = pandoc.utils.stringify(kwargs["fill"])
+      local color = pandoc.utils.stringify(kwargs["color"])
       if not isEmpty(size) then
         size = convert_fa_relative_size(size)
         size = "size: " .. size
       end
       
-      if not isEmpty(fill) then
-        fill = "fill: " .. fill
+      if not isEmpty(color) then
+        color = "fill: " .. color
         
         if not isEmpty(size) then
           size = size .. ", "
@@ -152,7 +152,7 @@ return {
 
       return pandoc.RawInline(
         'typst',
-        "#fa-" .. icon .. "(" .. size .. fill .. ")"
+        "#fa-" .. icon .. "(" .. size .. color .. ")"
         )
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -85,12 +85,13 @@ return {
       else
         return pandoc.RawInline('tex', "{\\" .. size .. "\\faIcon{" .. icon .. "}}")
       end
+    -- detect typst
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
-      if isEmpty(isValidSize(size)) then
+      if isEmpty(size) then
         return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
       else
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: ", size, ")")
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: " .. size .. ")")
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -10,6 +10,14 @@ local function ensureHtmlDeps()
   })
 end
 
+local function ensure_typst_font_awesome()
+  if included_font_awesome then
+    return
+  end
+  included_font_awesome = true
+  quarto.doc.include_text("in-header", "#import \"@preview/fontawesome:0.1.0\": *")
+end
+
 local function isEmpty(s)
   return s == nil or s == ''
 end
@@ -76,6 +84,13 @@ return {
         return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
       else
         return pandoc.RawInline('tex', "{\\" .. size .. "\\faIcon{" .. icon .. "}}")
+      end
+    elseif quarto.doc.is_format("typst") then
+      ensure_typst_font_awesome()
+      if isEmpty(isValidSize(size)) then
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
+      else
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: ", size, ")")
       end
     else
       return pandoc.Null()

--- a/example.qmd
+++ b/example.qmd
@@ -3,9 +3,11 @@ title: Font Awesome Quarto Extension
 format:
    html: default
    pdf: default
+   typst: default
 ---
 
-This extension allows you to use font-awesome icons in your Quarto HTML and PDF LaTeX and Typst documents.
+This extension allows you to use font-awesome icons in your Quarto HTML, PDF LaTeX, and Typst documents.
+
 It provides an `{{{< fa >}}}` shortcode:
 
 - Mandatory `<icon-name>`:
@@ -13,10 +15,12 @@ It provides an `{{{< fa >}}}` shortcode:
   {{{< fa <icon-name> >}}}
   ```
 
-- Optional `<group>`, `<size=...>`, and `<title=...>`:
+- Optional `<group>`, `<size=...>`, `<fill=...>`, `<title=...>`, and `<label=...>`:
   ``` markdown
-  {{{< fa <group> <icon-name> <size=...> <title=...> >}}}
+  {{{< fa <group> <icon-name> <size=...> <fill=...> <title=...> <label=...> >}}}
   ```
+
+The `title` and `label` parameters are only supported for the `html` format. The `fill` parameter is only supported for the `typst` format. The `typst` format also supports brand icons without any requirement to specify a `group` parameter.
 
 For example:
 
@@ -26,10 +30,27 @@ For example:
 | `{{{< fa folder >}}}`                              | {{< fa folder >}}                         |
 | `{{{< fa chess-pawn >}}}`                          | {{< fa chess-pawn >}}                     |
 | `{{{< fa brands bluetooth >}}}`                    | {{< fa brands bluetooth >}}               |
-| `{{{< fa brands twitter size=2xl >}}}` (HTML only) | {{< fa brands twitter size=2xl >}}        |
+| `{{{< fa battery-half size=Huge >}}}`             | {{< fa battery-half size=Huge >}}         |
+
+::: {.content-visible when-format="html"}
+HTML and Typst format-specific examples:
+
+| Shortcode                                          | Icon                                      |
+| -------------------------------------------------- | ----------------------------------------- |
+| `{{{< fa brands twitter size=2xl >}}}` (HTML and Typst only) | {{< fa brands twitter size=2xl >}}        |
 | `{{{< fa brands github size=5x >}}}` (HTML only)   | {{< fa brands github size=5x >}}          |
-| `{{{< fa battery-half size=Huge >}}}`              | {{< fa battery-half size=Huge >}}         |
-| `{{{< fa envelope title="An envelope" >}}}`        | {{< fa envelope title="An envelope" >}}   |
+| `{{{< fa envelope title="An envelope" >}}}` (HTML only)   | {{< fa envelope title="An envelope" >}}   |
+:::
+
+::: {.content-visible when-format="typst"}
+HTML and Typst format-specific examples:
+
+| Shortcode                                          | Icon                                      |
+| -------------------------------------------------- | ----------------------------------------- |
+| `{{{< fa brands twitter size=2xl >}}}` (HTML and Typst only) | {{< fa brands twitter size=2xl >}}        |
+| `{{{< fa pizza-slice size=2xl fill="red">}}}` (Typst only) | {{< fa pizza-slice size=2xl fill="red">}}        |
+
+:::
 
 Note that the icon sets are currently not perfectly interchangeable across formats:
 

--- a/example.qmd
+++ b/example.qmd
@@ -5,7 +5,7 @@ format:
    pdf: default
 ---
 
-This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents.
+This extension allows you to use font-awesome icons in your Quarto HTML and PDF LaTeX and Typst documents.
 It provides an `{{{< fa >}}}` shortcode:
 
 - Mandatory `<icon-name>`:
@@ -35,4 +35,5 @@ Note that the icon sets are currently not perfectly interchangeable across forma
 
 - `html` uses FontAwesome 6.4.2
 - `pdf` uses the `fontawesome5` package, based on [FontAwesome 5](https://ctan.org/pkg/fontawesome5).
+- `typst` uses the `typst-fontawesome` package
 - Other formats are currently not supported, but PRs are always welcome!

--- a/example.qmd
+++ b/example.qmd
@@ -15,12 +15,12 @@ It provides an `{{{< fa >}}}` shortcode:
   {{{< fa <icon-name> >}}}
   ```
 
-- Optional `<group>`, `<size=...>`, `<fill=...>`, `<title=...>`, and `<label=...>`:
+- Optional `<group>`, `<size=...>`, `<color=...>`, `<title=...>`, and `<label=...>`:
   ``` markdown
-  {{{< fa <group> <icon-name> <size=...> <fill=...> <title=...> <label=...> >}}}
+  {{{< fa <group> <icon-name> <size=...> <color=...> <title=...> <label=...> >}}}
   ```
 
-The `title` and `label` parameters are only supported for the `html` format. The `fill` parameter is only supported for the `typst` format. The `typst` format also supports brand icons without any requirement to specify a `group` parameter.
+The `title` and `label` parameters are only supported for the `html` format. The `color` parameter is only supported for the `typst` format. The `typst` format also supports brand icons without any requirement to specify a `group` parameter.
 
 For example:
 
@@ -48,7 +48,7 @@ HTML and Typst format-specific examples:
 | Shortcode                                          | Icon                                      |
 | -------------------------------------------------- | ----------------------------------------- |
 | `{{{< fa brands twitter size=2xl >}}}` (HTML and Typst only) | {{< fa brands twitter size=2xl >}}        |
-| `{{{< fa pizza-slice size=2xl fill="red">}}}` (Typst only) | {{< fa pizza-slice size=2xl fill="red">}}        |
+| `{{{< fa pizza-slice size=2xl color="red">}}}` (Typst only) | {{< fa pizza-slice size=2xl color="red">}}        |
 
 :::
 


### PR DESCRIPTION
Added support based on the examples/documentation here: https://typst.app/project/rQwGUWt5p33vrsb_uNPR9F

The ensure_typst_font_awesome function is copied from quarto-cli (I was unsure if there is someway to reuse it without creating it again) https://github.com/quarto-dev/quarto-cli/blob/312912c165a51f82f8fd0ba6b5f8e6f850294a90/src/resources/filters/customnodes/callout.lua#L665-L671