### PR TITLE
Use fontawesome 6 CTAN package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # development version
 
+-   Uses `fontawesome6` (<https://ctan.org/pkg/fontawesome6>) CTAN package for LaTeX now. This brings the same set of icons as FA 6.7.2 for LaTeX too. `regular` icons are now supported. (#42)
+
 -   Update to FontAwesome 6.7.2 for HTML. The HTML dependency inserted by the extension now uses the same version as the fontawesome assets included in the extension.
 
 # v1.2.0

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -1,5 +1,5 @@
 local function ensureLatexDeps()
-  quarto.doc.use_latex_package("fontawesome5")
+  quarto.doc.use_latex_package("fontawesome6")
 end
 
 local function ensureHtmlDeps()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -72,10 +72,15 @@ return {
     -- detect pdf / beamer / latex / etc
     elseif quarto.doc.is_format("pdf") then
       ensureLatexDeps()
+      local options = ""
+      if (group == "regular") then
+        options = "[regular]"
+      end
+      local icons = "\\faIcon" .. options .. "{" .. icon .. "}"
       if isEmpty(isValidSize(size)) then
-        return pandoc.RawInline('tex', "\\faIcon{" .. icon .. "}")
+        return pandoc.RawInline('tex', icons)
       else
-        return pandoc.RawInline('tex', "{\\" .. size .. "\\faIcon{" .. icon .. "}}")
+        return pandoc.RawInline('tex', "{\\" .. size .. icons .. "}")
       end
     else
       return pandoc.Null()

--- a/example.qmd
+++ b/example.qmd
@@ -3,6 +3,7 @@ title: Font Awesome Quarto Extension
 format:
    html: default
    pdf: default
+keep-tex: true
 ---
 
 This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents. It provides an `{{{< fa >}}}` shortcode:
@@ -27,19 +28,16 @@ For example:
 | `{{{< fa folder >}}}` | {{< fa folder >}} |
 | `{{{< fa chess-pawn >}}}` | {{< fa chess-pawn >}} |
 | `{{{< fa brands bluetooth >}}}` | {{< fa brands bluetooth >}} |
-| `{{{< fa brands twitter size=2xl >}}}` (HTML only) | {{< fa brands twitter size=2xl >}} |
-| `{{{< fa brands github size=5x >}}}` (HTML only) | {{< fa brands github size=5x >}} |
+| `{{{< fa brands twitter size=2xl >}}}` | {{< fa brands twitter size=2xl >}} |
+| `{{{< fa brands github size=5x >}}}` | {{< fa brands github size=5x >}} |
 | `{{{< fa battery-half size=Huge >}}}` | {{< fa battery-half size=Huge >}} |
 | `{{{< fa envelope title="An envelope" >}}}` | {{< fa envelope title="An envelope" >}} |
 
 Note that the icon sets are currently not perfectly interchangeable across formats:
 
--   `html` uses FontAwesome 6.7.2
--   `pdf` uses the `fontawesome5` package, based on [FontAwesome 5](https://ctan.org/pkg/fontawesome5).
+-   `html` uses FontAwesome 6.7.2 from <<https://github.com/FortAwesome/Font-Awesome>
+-   `pdf` uses the [`fontawesome6`](https://ctan.org/pkg/fontawesome6) package, based on FontAwesome 6.7.2 too.
 -   Other formats are currently not supported, but PRs are always welcome!
-
-
-::: {.content-visible when-format="html"}
 
 ## Available Icons Reference
 
@@ -67,7 +65,7 @@ These icons work without specifying a group:
 | {{< fa globe >}} | `globe` | {{< fa cloud >}} | `cloud` | {{< fa fire >}} | `fire` |
 | {{< fa bolt >}} | `bolt` | {{< fa sun >}} | `sun` | {{< fa moon >}} | `moon` |
 | {{< fa music >}} | `music` | {{< fa image >}} | `image` | {{< fa video >}} | `video` |
-| {{< fa shopping-cart >}} | `shopping-cart` | {{< fa credit-card >}} | `credit-card` | {{< fa gift >}} | `gift` |
+| {{< fa cart-shopping >}} | `shopping-cart` | {{< fa credit-card >}} | `credit-card` | {{< fa gift >}} | `gift` |
 | {{< fa truck >}} | `truck` | {{< fa plane >}} | `plane` | {{< fa car >}} | `car` |
 | {{< fa laptop >}} | `laptop` | {{< fa mobile >}} | `mobile` | {{< fa tablet >}} | `tablet` |
 | {{< fa database >}} | `database` | {{< fa server >}} | `server` | {{< fa wifi >}} | `wifi` |
@@ -130,5 +128,3 @@ For a complete searchable list of all 2,000+ icons, visit the [Font Awesome Icon
 -   Brand icons require the `brands` group: `{{{< fa brands icon-name >}}}`
 -   Regular icons can use the `regular` group: `{{{< fa regular icon-name >}}}`
 -   Solid icons (default) can optionally use `solid` group: `{{{< fa solid icon-name >}}}`
- 
-:::

--- a/example.qmd
+++ b/example.qmd
@@ -3,7 +3,6 @@ title: Font Awesome Quarto Extension
 format:
    html: default
    pdf: default
-keep-tex: true
 ---
 
 This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents. It provides an `{{{< fa >}}}` shortcode:
@@ -20,12 +19,19 @@ This extension allows you to use font-awesome icons in your Quarto HTML and PDF 
     {{{< fa <group> <icon-name> <size=...> <title=...> >}}}
     ```
 
+    `group` defaults to `solid`.
+
 For example:
 
 | Shortcode | Icon |
 |---------------------------------------|---------------------------------|
 | `{{{< fa thumbs-up >}}}` | {{< fa thumbs-up >}} |
+| `{{{< fa solid thumbs-up >}}}` | {{< fa solid thumbs-up >}} |
+| `{{{< fa regular thumbs-up >}}}` | {{< fa regular thumbs-up >}} |
 | `{{{< fa folder >}}}` | {{< fa folder >}} |
+| `{{{< fa regular folder >}}}` | {{< fa regular folder >}} |
+| `{{{< fa heart >}}}` | {{< fa heart >}} |
+| `{{{< fa regular heart >}}}` | {{< fa regular heart >}} |
 | `{{{< fa chess-pawn >}}}` | {{< fa chess-pawn >}} |
 | `{{{< fa brands bluetooth >}}}` | {{< fa brands bluetooth >}} |
 | `{{{< fa brands twitter size=2xl >}}}` | {{< fa brands twitter size=2xl >}} |


### PR DESCRIPTION
closes #42 

It uses the new package `fontawesome6` with the same icons as FA 6.7.2 on HTML. 

It also bring support for `regular` icons on PDF now. 