### PR TITLE
Add Typst support with feature parity to HTML and LaTeX PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Font Awesome Extension for Quarto
 
-This extension provides support including free icons provided by [Font Awesome](https://fontawesome.com). Icons can be used in both HTML (via [Font Awesome 6 Free](https://fontawesome.com/search?m=free)) and PDF (via the [fontawesome5 LaTeX package](https://ctan.org/pkg/fontawesome5?lang=en)).
+This extension provides support including free icons provided by [Font Awesome](https://fontawesome.com). Icons can be used in HTML (via [Font Awesome 6.7.2](https://fontawesome.com/search?m=free)), PDF (via the [fontawesome6 LaTeX package](https://ctan.org/pkg/fontawesome6)), and Typst (via the [fontawesome Typst package](https://typst.app/universe/package/fontawesome)).
 
 ## Installing
 
@@ -35,10 +35,10 @@ You can browse all of the available free icons here:
 
 All icons available in this extensions are coming from <https://github.com/FortAwesome/Font-Awesome>
 
-### Brands[^1]
+### Brands
 
 Note that there is a `brands` prefix used within the `bluetooth` example above.
-If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier when using any HTML format.
+If you choose an icon from the `brands` collection, you will need to add a `brands` collection specifier.
 For example, if you search the free icons for "github" and then click on the `github` icon, you'll see this as the suggested HTML to embed the icon:
 
 ```html
@@ -53,51 +53,52 @@ The `fa-brands` indicates that the icon is in the `brands` collection. To use th
 
 ### Sizing Icons
 
-Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>.  
-When the size is invalid, no size changes are made.
+Font Awesome provides relative and literal sizing for icons as described in <https://fontawesome.com/docs/web/style/size>. Using these sizing values will work for HTML and PDF with Typst. For PDF through LaTeX, only using the named values related to LaTeX command will work, and in that case they are translated to compatible sized for HTML and PDF with Typst. 
+
+When the `size` option is passed an invalid value, no size changes are made.
 
 - Relative sizing[^1]: `{{< fa battery-half size=2xl >}}`.
 
   | Relative Sizing Class | Font Size | Equivalent in Pixels |
   |-----------------------|-----------|----------------------|
-  | fa-2xs                | 0.625em   | 10px                 |
-  | fa-xs                 | 0.75em    | 12px                 |
-  | fa-sm                 | 0.875em   | 14px                 |
-  | fa-lg                 | 1.25em    | 20px                 |
-  | fa-xl                 | 1.5em     | 24px                 |
-  | fa-2xl                | 2em       | 32px                 |
+  | 2xs                   | 0.625em   | 10px                 |
+  | xs                    | 0.75em    | 12px                 |
+  | sm                    | 0.875em   | 14px                 |
+  | lg                    | 1.25em    | 20px                 |
+  | xl                    | 1.5em     | 24px                 |
+  | 2xl                   | 2em       | 32px                 |
 
 - Literal sizing[^1]: `{{< fa battery-half size=5x >}}`.
 
   | Literal Sizing Class | Font Size |
   |----------------------|-----------|
-  | fa-1x                | 1em       |
-  | fa-2x                | 2em       |
-  | fa-3x                | 3em       |
-  | fa-4x                | 4em       |
-  | fa-5x                | 5em       |
-  | fa-6x                | 6em       |
-  | fa-7x                | 7em       |
-  | fa-8x                | 8em       |
-  | fa-9x                | 9em       |
-  | fa-10x               | 10em      |
+  | 1x                   | 1em       |
+  | 2x                   | 2em       |
+  | 3x                   | 3em       |
+  | 4x                   | 4em       |
+  | 5x                   | 5em       |
+  | 6x                   | 6em       |
+  | 7x                   | 7em       |
+  | 8x                   | 8em       |
+  | 9x                   | 9em       |
+  | 10x                  | 10em      |
 
-- LaTeX sizing: `{{< fa battery-half size=Huge >}}`.
+- LaTeX sizing[^2]: `{{< fa battery-half size=Huge >}}`.
 
-  | Sizing Command                   | Font Size (LaTeX)    | Font Size (HTML) |
-  | -------------------------------- | -------------------- | ---------------- |
-  | tiny (= `\tiny`)                 | 5pt                  | 0.5em            |
-  | scriptsize (= `\scriptsize`)     | 7pt                  | 0.7em            |
-  | footnotesize (= `\footnotesize`) | 8pt                  | 0.8em            |
-  | small (= `\small`)               | 9pt                  | 0.9em            |
-  | normalsize (= `\normalsize`)     | 10pt (document size) | 1em              |
-  | large (= `\large`)               | 12pt                 | 1.25em           |
-  | Large (= `\Large`)               | 14.4pt               | 1.5em            |
-  | LARGE (= `\LARGE`)               | 17.28pt              | 1.75em           |
-  | huge (= `\huge`)                 | 20.74pt              | 2em              |
-  | Huge (= `\Huge`)                 | 24.88pt              | 2.5em            |
+  | Sizing Command                   | Font Size (PDF)      | Font Size (HTML/Typst) |
+  | -------------------------------- | -------------------- | ---------------------- |
+  | tiny (= `\tiny`)                 | 5pt                  | 0.5em                  |
+  | scriptsize (= `\scriptsize`)     | 7pt                  | 0.7em                  |
+  | footnotesize (= `\footnotesize`) | 8pt                  | 0.8em                  |
+  | small (= `\small`)               | 9pt                  | 0.9em                  |
+  | normalsize (= `\normalsize`)     | 10pt (document size) | 1em                    |
+  | large (= `\large`)               | 12pt                 | 1.2em                  |
+  | Large (= `\Large`)               | 14.4pt               | 1.5em                  |
+  | LARGE (= `\LARGE`)               | 17.28pt              | 1.75em                 |
+  | huge (= `\huge`)                 | 20.74pt              | 2em                    |
+  | Huge (= `\Huge`)                 | 24.88pt              | 2.5em                  |
 
-### Accessibility[^1]
+### Accessibility[^3]
 
 If the icon is being used in place of some text,
 just add some descriptive text in the title argument:
@@ -114,7 +115,9 @@ This will produce the following HTML:
 
 More details on Font Awesome accessibility at <https://fontawesome.com/docs/web/dig-deeper/accessibility>.
 
-[^1]: HTML formats only.
+[^1]: HTML and Typst formats only.
+[^2]: All formats supported.
+[^3]: HTML format only.
 
 ## Example
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -50,7 +50,17 @@ local function convert_fa_relative_size(size)
     "sm",
     "lg",
     "xl",
-    "2xl"
+    "2xl",
+    "tiny",
+    "scriptsize",
+    "footnotesize",
+    "small",
+    "normalsize",
+    "large",
+    "Large",
+    "LARGE",
+    "huge",
+    "Huge"
   }
   
   local relativeSizes = {
@@ -59,7 +69,17 @@ local function convert_fa_relative_size(size)
     "0.875em",
     "1.25em",
     "1.5em",
-    "2em"
+    "2em",
+    "0.125em",
+    "0.5em",
+    "0.625em",
+    "0.75em",
+    "0.875em",
+    "1.25em",
+    "1.5em",
+    "2em",
+    "2.5em",
+    "3em"
   }
   
   for i, v in ipairs(validSizes) do
@@ -122,26 +142,23 @@ return {
       ensure_typst_font_awesome()
       
       local fill = pandoc.utils.stringify(kwargs["fill"])
-      if not isEmpty(fill) then
-        fill = ", fill: " .. fill
-      end
-      
       if not isEmpty(size) then
         size = convert_fa_relative_size(size)
-        size = ", size: " .. size
+        size = "size: " .. size
       end
       
-      if group == "brands" then
-        return pandoc.RawInline(
-          'typst',
-          "#fa-icon(\"" .. icon .. "\", fa-set: \"Brands\"" .. size .. fill .. ")"
-          )
-      else
-        return pandoc.RawInline(
-            'typst',
-            "#fa-icon(\"" .. icon .. "\"" .. size .. fill .. ")"
-            )
+      if not isEmpty(fill) then
+        fill = "fill: " .. fill
+        
+        if not isEmpty(size) then
+          size = size .. ", "
+        end
       end
+
+      return pandoc.RawInline(
+        'typst',
+        "#fa-" .. icon .. "(" .. size .. fill .. ")"
+        )
     else
       return pandoc.Null()
     end

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -16,6 +16,8 @@ local function ensure_typst_font_awesome()
   if not included_font_awesome then
     included_font_awesome = true
     quarto.doc.include_text('in-header', '#import "@preview/fontawesome:0.6.0": *')
+    -- Opt-in version 6 for now
+    quarto.doc.include_text('in-header', 'fa-version("6")')
   end
 end
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -142,23 +142,9 @@ return {
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
       
-      local color = pandoc.utils.stringify(kwargs["color"])
-      if not isEmpty(size) then
-        size = convert_fa_relative_size(size)
-        size = "size: " .. size
-      end
-      
-      if not isEmpty(color) then
-        color = "fill: " .. color
-        
-        if not isEmpty(size) then
-          size = size .. ", "
-        end
-      end
-
       return pandoc.RawInline(
         'typst',
-        "#fa-" .. icon .. "(" .. size .. color .. ")"
+        "#fa-" .. icon .. "(" .. size .. ")"
         )
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -10,6 +10,14 @@ local function ensureHtmlDeps()
   })
 end
 
+local function ensure_typst_font_awesome()
+  if included_font_awesome then
+    return
+  end
+  included_font_awesome = true
+  quarto.doc.include_text("in-header", "#import \"@preview/fontawesome:0.1.0\": *")
+end
+
 local function isEmpty(s)
   return s == nil or s == ''
 end
@@ -81,6 +89,13 @@ return {
         return pandoc.RawInline('tex', icons)
       else
         return pandoc.RawInline('tex', "{\\" .. size .. icons .. "}")
+      end
+    elseif quarto.doc.is_format("typst") then
+      ensure_typst_font_awesome()
+      if isEmpty(isValidSize(size)) then
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
+      else
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: ", size, ")")
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -43,6 +43,33 @@ local function isValidSize(size)
   return ""
 end
 
+local function convert_fa_relative_size(size)
+  local validSizes = {
+    "2xs",
+    "xs",
+    "sm",
+    "lg",
+    "xl",
+    "2xl"
+  }
+  
+  local relativeSizes = {
+    "0.625em",
+    "0.75em",
+    "0.875em",
+    "1.25em",
+    "1.5em",
+    "2em"
+  }
+  
+  for i, v in ipairs(validSizes) do
+    if v == size then
+      return relativeSizes[i]
+    end
+  end
+  return size
+end
+
 return {
   ["fa"] = function(args, kwargs)
 
@@ -93,10 +120,27 @@ return {
     -- detect typst
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
-      if isEmpty(size) then
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
+      
+      local fill = pandoc.utils.stringify(kwargs["fill"])
+      if not isEmpty(fill) then
+        fill = ", fill: " .. fill
+      end
+      
+      if not isEmpty(size) then
+        size = convert_fa_relative_size(size)
+        size = ", size: " .. size
+      end
+      
+      if group == "brands" then
+        return pandoc.RawInline(
+          'typst',
+          "#fa-icon(\"" .. icon .. "\", fa-set: \"Brands\"" .. size .. fill .. ")"
+          )
       else
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: " .. size .. ")")
+        return pandoc.RawInline(
+            'typst',
+            "#fa-icon(\"" .. icon .. "\"" .. size .. fill .. ")"
+            )
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -17,7 +17,7 @@ local function ensure_typst_font_awesome()
     included_font_awesome = true
     quarto.doc.include_text('in-header', '#import "@preview/fontawesome:0.6.0": *')
     -- Opt-in version 6 for now
-    quarto.doc.include_text('in-header', 'fa-version("6")')
+    quarto.doc.include_text('in-header', '#fa-version("6")')
   end
 end
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -90,12 +90,13 @@ return {
       else
         return pandoc.RawInline('tex', "{\\" .. size .. icons .. "}")
       end
+    -- detect typst
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
-      if isEmpty(isValidSize(size)) then
+      if isEmpty(size) then
         return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\")")
       else
-        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: ", size, ")")
+        return pandoc.RawInline('typst', "#fa-icon(\"" .. icon .. "\", size: " .. size .. ")")
       end
     else
       return pandoc.Null()

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -10,12 +10,13 @@ local function ensureHtmlDeps()
   })
 end
 
+local included_font_awesome = false
+
 local function ensure_typst_font_awesome()
-  if included_font_awesome then
-    return
+  if not included_font_awesome then
+    included_font_awesome = true
+    quarto.doc.include_text('in-header', '#import "@preview/fontawesome:0.6.0": *')
   end
-  included_font_awesome = true
-  quarto.doc.include_text("in-header", "#import \"@preview/fontawesome:0.1.0\": *")
 end
 
 local function isEmpty(s)

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -87,8 +87,8 @@ local function convert_fa_relative_size(size)
     return sizeMap[size]
   end
 
-  -- If not found, return original size (allows custom em values)
-  return size
+  -- If not found, ignore size
+  return ''
 end
 
 return {
@@ -141,11 +141,30 @@ return {
     -- detect typst
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
-      
+
+      -- Build array of parameters for fa-icon()
+      local params = {'"' .. icon .. '"'}
+
+      -- Add size parameter if specified and valid
+      local sizeValue = convert_fa_relative_size(size)
+      if not isEmpty(sizeValue) then
+        table.insert(params, "size: " .. sizeValue)
+      end
+
+      -- Add solid parameter based on group
+      if group == "regular" then
+        table.insert(params, "solid: false")
+      elseif group == "solid" then
+        table.insert(params, "solid: true")
+      end
+
+      -- Join parameters with comma-space separator
+      local iconContent = table.concat(params, ", ")
+
       return pandoc.RawInline(
         'typst',
-        "#fa-" .. icon .. "(" .. size .. ")"
-        )
+        '#fa-icon(' .. iconContent .. ')'
+      )
     else
       return pandoc.Null()
     end

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -47,49 +47,47 @@ local function isValidSize(size)
 end
 
 local function convert_fa_relative_size(size)
-  local validSizes = {
-    "2xs",
-    "xs",
-    "sm",
-    "lg",
-    "xl",
-    "2xl",
-    "tiny",
-    "scriptsize",
-    "footnotesize",
-    "small",
-    "normalsize",
-    "large",
-    "Large",
-    "LARGE",
-    "huge",
-    "Huge"
+  -- Map of Font Awesome size names to em values
+  -- Includes both CSS sizes (2xs, xs, sm, lg, xl, 2xl, 1x-10x)
+  -- and LaTeX sizes (tiny, scriptsize, etc.)
+  local sizeMap = {
+    -- Font Awesome CSS relative sizes
+    ["2xs"] = "0.625em",
+    ["xs"] = "0.75em",
+    ["sm"] = "0.875em",
+    ["lg"] = "1.25em",
+    ["xl"] = "1.5em",
+    ["2xl"] = "2em",
+    -- Font Awesome CSS multiplier sizes
+    ["1x"] = "1em",
+    ["2x"] = "2em",
+    ["3x"] = "3em",
+    ["4x"] = "4em",
+    ["5x"] = "5em",
+    ["6x"] = "6em",
+    ["7x"] = "7em",
+    ["8x"] = "8em",
+    ["9x"] = "9em",
+    ["10x"] = "10em",
+    -- LaTeX size names (matches latex-fontsize.css for consistency)
+    ["tiny"] = "0.5em",
+    ["scriptsize"] = "0.7em",
+    ["footnotesize"] = "0.8em",
+    ["small"] = "0.9em",
+    ["normalsize"] = "1em",
+    ["large"] = "1.2em",
+    ["Large"] = "1.5em",
+    ["LARGE"] = "1.75em",
+    ["huge"] = "2em",
+    ["Huge"] = "2.5em"
   }
-  
-  local relativeSizes = {
-    "0.625em",
-    "0.75em",
-    "0.875em",
-    "1.25em",
-    "1.5em",
-    "2em",
-    "0.125em",
-    "0.5em",
-    "0.625em",
-    "0.75em",
-    "0.875em",
-    "1.25em",
-    "1.5em",
-    "2em",
-    "2.5em",
-    "3em"
-  }
-  
-  for i, v in ipairs(validSizes) do
-    if v == size then
-      return relativeSizes[i]
-    end
+
+  -- Check if size is in the map
+  if sizeMap[size] then
+    return sizeMap[size]
   end
+
+  -- If not found, return original size (allows custom em values)
   return size
 end
 

--- a/_extensions/fontawesome/fontawesome.lua
+++ b/_extensions/fontawesome/fontawesome.lua
@@ -141,14 +141,14 @@ return {
     elseif quarto.doc.is_format("typst") then
       ensure_typst_font_awesome()
       
-      local fill = pandoc.utils.stringify(kwargs["fill"])
+      local color = pandoc.utils.stringify(kwargs["color"])
       if not isEmpty(size) then
         size = convert_fa_relative_size(size)
         size = "size: " .. size
       end
       
-      if not isEmpty(fill) then
-        fill = "fill: " .. fill
+      if not isEmpty(color) then
+        color = "fill: " .. color
         
         if not isEmpty(size) then
           size = size .. ", "
@@ -157,7 +157,7 @@ return {
 
       return pandoc.RawInline(
         'typst',
-        "#fa-" .. icon .. "(" .. size .. fill .. ")"
+        "#fa-" .. icon .. "(" .. size .. color .. ")"
         )
     else
       return pandoc.Null()

--- a/example.qmd
+++ b/example.qmd
@@ -3,9 +3,11 @@ title: Font Awesome Quarto Extension
 format:
    html: default
    pdf: default
+   typst: default
 ---
 
-This extension allows you to use font-awesome icons in your Quarto HTML and PDF LaTeX and Typst documents.
+This extension allows you to use font-awesome icons in your Quarto HTML, PDF LaTeX, and Typst documents.
+
 It provides an `{{{< fa >}}}` shortcode:
 
 -   Mandatory `<icon-name>`:

--- a/example.qmd
+++ b/example.qmd
@@ -3,7 +3,8 @@ title: Font Awesome Quarto Extension
 format:
    html: default
    pdf: default
-   typst: default
+   typst: 
+    output-file: example-typst.pdf
 ---
 
 This extension allows you to use font-awesome icons in your Quarto HTML, PDF LaTeX, and Typst documents.

--- a/example.qmd
+++ b/example.qmd
@@ -138,3 +138,60 @@ For a complete searchable list of all 2,000+ icons, visit the [Font Awesome Icon
 -   Brand icons require the `brands` group: `{{{< fa brands icon-name >}}}`
 -   Regular icons can use the `regular` group: `{{{< fa regular icon-name >}}}`
 -   Solid icons (default) can optionally use `solid` group: `{{{< fa solid icon-name >}}}`
+
+## Sizing Icons
+
+Font Awesome provides relative and literal sizing for icons. When the size is invalid, no size changes are made.
+
+### Relative Sizing^[HTML and Typst formats only]
+
+Usage: `{{{< fa battery-half size=2xl >}}}`
+
+| Relative Sizing Class | Font Size | Equivalent in Pixels |
+|-----------------------|-----------|----------------------|
+| 2xs                   | 0.625em   | 10px                 |
+| xs                    | 0.75em    | 12px                 |
+| sm                    | 0.875em   | 14px                 |
+| lg                    | 1.25em    | 20px                 |
+| xl                    | 1.5em     | 24px                 |
+| 2xl                   | 2em       | 32px                 |
+
+Example: {{< fa heart size=2xs >}} {{< fa heart size=xs >}} {{< fa heart size=sm >}} {{< fa heart >}} {{< fa heart size=lg >}} {{< fa heart size=xl >}} {{< fa heart size=2xl >}}
+
+### Literal Sizing^[HTML and Typst formats only]
+
+Usage: `{{{< fa battery-half size=5x >}}}`
+
+| Literal Sizing Class | Font Size |
+|----------------------|-----------|
+| 1x                   | 1em       |
+| 2x                   | 2em       |
+| 3x                   | 3em       |
+| 4x                   | 4em       |
+| 5x                   | 5em       |
+| 6x                   | 6em       |
+| 7x                   | 7em       |
+| 8x                   | 8em       |
+| 9x                   | 9em       |
+| 10x                  | 10em      |
+
+Example: {{< fa star size=1x >}} {{< fa star size=2x >}} {{< fa star size=3x >}} {{< fa star size=4x >}} {{< fa star size=5x >}} {{< fa star size=6x >}} {{< fa star size=7x >}}
+
+### LaTeX Sizing^[All formats supported]
+
+Usage: `{{{< fa battery-half size=Huge >}}}`
+
+| Sizing Command | LaTeX | HTML & Typst |
+|----------------|-------|--------------|
+| tiny           | 5pt   | 0.5em        |
+| scriptsize     | 7pt   | 0.7em        |
+| footnotesize   | 8pt   | 0.8em        |
+| small          | 9pt   | 0.9em        |
+| normalsize     | 10pt  | 1em          |
+| large          | 12pt  | 1.2em        |
+| Large          | 14.4pt| 1.5em        |
+| LARGE          | 17.28pt| 1.75em      |
+| huge           | 20.74pt| 2em         |
+| Huge           | 24.88pt| 2.5em       |
+
+Example: {{< fa circle size=tiny >}} {{< fa circle size=scriptsize >}} {{< fa circle size=footnotesize >}} {{< fa circle size=small >}} {{< fa circle size=normalsize >}} {{< fa circle size=large >}} {{< fa circle size=Large >}} {{< fa circle size=LARGE >}} {{< fa circle size=huge >}} {{< fa circle size=Huge >}}

--- a/example.qmd
+++ b/example.qmd
@@ -5,7 +5,8 @@ format:
    pdf: default
 ---
 
-This extension allows you to use font-awesome icons in your Quarto HTML and PDF documents. It provides an `{{{< fa >}}}` shortcode:
+This extension allows you to use font-awesome icons in your Quarto HTML and PDF LaTeX and Typst documents.
+It provides an `{{{< fa >}}}` shortcode:
 
 -   Mandatory `<icon-name>`:
 
@@ -43,6 +44,7 @@ Note that the icon sets are currently not perfectly interchangeable across forma
 
 -   `html` uses FontAwesome 6.7.2 from <<https://github.com/FortAwesome/Font-Awesome>
 -   `pdf` uses the [`fontawesome6`](https://ctan.org/pkg/fontawesome6) package, based on FontAwesome 6.7.2 too.
+-   `typst` uses the `typst-fontawesome` package
 -   Other formats are currently not supported, but PRs are always welcome!
 
 ## Available Icons Reference


### PR DESCRIPTION
closes #31 
closes #36

This builds on #36 and work by @elipousson 

This PR 
- does keep the basic support added in #36 but remove the color addition (to be dealt with in #35 )
- It does also rebase on latest dev version (with v6.7.2 support in HTML and LaTeX)
- And it adds feature parity support with current state of extension, meaning
  - All CSS sizing for HTML needs to be supported with `em` conversion in typst. Values from the CSS are used
  - Default icons in this extension are `solid` type. Typst package default to regular so this is changed.
  - FA v6 is configured as v7 is not yet supported

This PR seems to be ok and produce this PDF 
[example-typst.pdf](https://github.com/user-attachments/files/22778496/example-typst.pdf)
 
However, I am puzzled because we're missing font handling. 
- Docs says that fonts needs to be installed and they are not shipped (https://typst.app/universe/package/fontawesome#usage)
- But document still renders with unicode (at least on windows) while I don't have the font installed

Also, while doing `quarto render` I don't see warning. but adding `keep-typ: true` and calling `quarto typst compile` does show expected message

````
❯ quarto render .\example.qmd --to typst
pandoc 
  to: typst
  output-file: example.typ
  standalone: true
  shift-heading-level-by: -1
  default-image-extension: svg
  wrap: none
  citeproc: false
  variables: {}

metadata
  title: Font Awesome Quarto Extension

[typst]: Compiling example.typ to example.pdf...DONE

Output created: example-typst.pdf
````

```
❯ quarto typst compile .\example.typ
warning: unknown font family: font awesome 6 free solid
   ┌─ @preview/fontawesome:0.6.0\lib-impl.typ:80:12
   │
80 │       font: default_fonts, // If you see warning here, please check whether the FA font is installed
   │             ^^^^^^^^^^^^^

warning: unknown font family: font awesome 6 brands
   ┌─ @preview/fontawesome:0.6.0\lib-impl.typ:80:12
   │
80 │       font: default_fonts, // If you see warning here, please check whether the FA font is installed
   │             ^^^^^^^^^^^^^

warning: unknown font family: font awesome 6 free
   ┌─ @preview/fontawesome:0.6.0\lib-impl.typ:80:12
   │
80 │       font: default_fonts, // If you see warning here, please check whether the FA font is installed
   │             ^^^^^^^^^^^^^
```

So we need a way to provide new font in Typst font path from an extension. Probably related to
- https://github.com/quarto-dev/quarto-cli/issues/13518

So maybe Typst support needs to wait for 1.9 ? 